### PR TITLE
Fix options passing for open()

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,9 @@ function startBrowserProcess(browser, url, args) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, wait: false, url: true };
+    var options = { app: {
+      name: browser
+    }, wait: false, url: true };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -145,16 +145,12 @@ function startBrowserProcess(browser, url, args) {
     browser = undefined;
   }
 
-  // If there are arguments, they must be passed as array with the browser
-  if (typeof browser === 'string' && args.length > 0) {
-    browser = [browser].concat(args);
-  }
-
   // Fallback to open
   // (It will always open new tab)
   try {
     var options = { app: {
-      name: browser
+      name: browser,
+      arguments: typeof browser === 'string' && args.length > 0 ? args : []
     }, wait: false, url: true };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;


### PR DESCRIPTION
I checked the code in open package and it expects that options.app is an object with "name".
https://github.com/sindresorhus/open/blob/cbc008bab21f657475b54e33a823b2941737da6f/index.js#L107.

Also arguments should be passed in "arguments" property instead of concatenation.